### PR TITLE
add main que setup per React Native 0.49 and above

### DIFF
--- a/ios/ReactNativeNfcIos.m
+++ b/ios/ReactNativeNfcIos.m
@@ -10,6 +10,11 @@
 
 RCT_EXPORT_MODULE();
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 - (instancetype)init
 {
     self = [super init];


### PR DESCRIPTION
"Module ReactNativeNfcIos requires main queue setup since it overrides constantsToExport but doesn't implement `requiresMainQueueSetup. In a future release, React Native will default to initializing all native modules on a background thread unless explicitly opted-out of."